### PR TITLE
Add async interface

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,7 @@
-(defproject clanhr/memory-gateway "0.6.0"
+(defproject clanhr/memory-gateway "0.7.0"
   :description "Simple in memory datastore for unit tests"
   :url "https://github.com/clanhr/memory-gateway"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0-beta3"]])
+  :dependencies [[org.clojure/clojure "1.7.0-RC1"]
+                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]])

--- a/src/clanhr/memory_gateway/async.clj
+++ b/src/clanhr/memory_gateway/async.clj
@@ -1,0 +1,20 @@
+(ns clanhr.memory-gateway.async
+  "Memory async gateway utilities"
+  (:require [clanhr.memory-gateway.core :as core]
+            [clojure.core.async :refer [go]]))
+
+(defn save!
+  "Returns a channel with the result"
+  [& args]
+  (go (apply core/save! args)))
+
+(defn get-model
+  "Returns a channel with the result"
+  [& args]
+  (go (apply core/get-model args)))
+
+(defn paginated-query
+  "Returns a channel with the result"
+  [& args]
+  (go (apply core/paginated-query args)))
+

--- a/test/clanhr/memory_gateway/async_test.clj
+++ b/test/clanhr/memory_gateway/async_test.clj
@@ -1,0 +1,20 @@
+(ns clanhr.memory-gateway.async-test
+  (:require [clojure.test :refer :all]
+            [clanhr.memory-gateway.core :as core]
+            [clanhr.memory-gateway.async :as core-async]
+            [clojure.core.async :refer [<!!]]))
+
+(deftest saving-with-global-atoms
+  (let [model {:text "Hello"}
+        result (<!! (core-async/save! model))]
+    (let [loaded (<!! (core-async/get-model (result :_id)))]
+      (is (= "Hello" (:text loaded))))))
+
+(deftest saving-with-given-atoms
+  (let [datastore (core/datastore-atom)
+        counter (core/counter-atom)
+        model {:text "Hello"}
+        result (<!! (core-async/save! model datastore counter))]
+    (let [loaded (<!! (core-async/get-model (result :_id) datastore))]
+      (is (= "Hello" (:text loaded))))))
+


### PR DESCRIPTION
Add core.async interface. Implemented core functions as core.async
channels. At this moment this functions just act lik a proxy and wrap
the core ones in a go context (go returns a channel with the result
from the last expression).
